### PR TITLE
Fix for bool? shared editor for child items.

### DIFF
--- a/BootstrappingMvc/Views/Shared/EditorTemplates/SwitchedBoolean.cshtml
+++ b/BootstrappingMvc/Views/Shared/EditorTemplates/SwitchedBoolean.cshtml
@@ -13,14 +13,10 @@
     }
 
     @Html.HiddenFor(model => model)
+    <div class="btn-group grp-bool" data-toggle="buttons">
+        <label class="btn btn-primary @yesSelected"><input type="radio" name="bool-@htmlField" onchange="javascript:$('@htmlField').val(true);" />Yes</label>
+        <label class="btn btn-primary @noSelected"><input type="radio" name="bool-@htmlField" onchange="javascript:$('@htmlField').val(false);" />No</label>
 
-    <div class="btn-group" data-toggle="buttons-radio">
-        <button type="button" class="btn btn-info @yesSelected bool-@htmlField" onclick="javascript:$('@htmlField').val(true);" >Yes</button>
-        <button type="button" class="btn btn-info @noSelected bool-@htmlField" onclick="javascript:$('@htmlField').val(false);" >No</button>
-    
         @if (ViewData.ModelMetadata.IsNullableValueType)
-            { <button type="button" class="btn btn-info @noSelection bool-@htmlField" onclick="javascript:$('@htmlField').val('');" >Do Not Set</button> }
-
+        { <label class="btn btn-primary @noSelection"><input type="radio" name="bool-@htmlField" onchange="javascript:$('@htmlField').val('');" />N/A</label> }
     </div>
-
-

--- a/BootstrappingMvc/Views/Shared/EditorTemplates/SwitchedBoolean.cshtml
+++ b/BootstrappingMvc/Views/Shared/EditorTemplates/SwitchedBoolean.cshtml
@@ -6,18 +6,20 @@
         var noSelected = Model.HasValue && !Model.Value ? "active" : null;
         var noSelection = !Model.HasValue ? "active" : null;   
     
-        // get the name of the ID - this is to support multiple fields     
-        var htmlField = ViewData.TemplateInfo.HtmlFieldPrefix;
+        // get the name of the ID - this is to support multiple fields
+        // If the editor is for a child element, the field prefix does not match the element Id (but it still matches the name).
+        // In this case Razor uses dot notation in the name while keeping underscore notation in the Id.  HtmlFieldPrefix returns dot notation.
+        var htmlField = @"[name=""" + ViewData.TemplateInfo.HtmlFieldPrefix + @"""]";
     }
 
     @Html.HiddenFor(model => model)
 
     <div class="btn-group" data-toggle="buttons-radio">
-        <button type="button" class="btn btn-info @yesSelected bool-@htmlField" onclick="javascript:$('#@htmlField').val(true);" >Yes</button>
-        <button type="button" class="btn btn-info @noSelected bool-@htmlField" onclick="javascript:$('#@htmlField').val(false);" >No</button>
+        <button type="button" class="btn btn-info @yesSelected bool-@htmlField" onclick="javascript:$('@htmlField').val(true);" >Yes</button>
+        <button type="button" class="btn btn-info @noSelected bool-@htmlField" onclick="javascript:$('@htmlField').val(false);" >No</button>
     
         @if (ViewData.ModelMetadata.IsNullableValueType)
-            { <button type="button" class="btn btn-info @noSelection bool-@htmlField" onclick="javascript:$('#@htmlField').val('');" >Do Not Set</button> }
+            { <button type="button" class="btn btn-info @noSelection bool-@htmlField" onclick="javascript:$('@htmlField').val('');" >Do Not Set</button> }
 
     </div>
 


### PR DESCRIPTION
HtmlFieldPrefix returns the field name using dot notation while naming the elements with underscores.  Fortunately the dot notation is still placed in the name attribute so we can search on that instead of Id and work in more situations.

Updated the EditorFor<bool?> template so that the value will be set on name instead of Id.  This seems to work for both parent and child items.